### PR TITLE
Name service in Open Liberty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,10 @@
         <version.javax.inject>1</version.javax.inject>
         <version.jackson.databind>2.8.4</version.jackson.databind>
         <version.jackson.annotations>2.8.4</version.jackson.annotations>
+        <!-- Open Liberty -->
+        <version.liberty-maven-plugin>2.2</version.liberty-maven-plugin>
+        <version.openliberty-runtime>RELEASE</version.openliberty-runtime>
+        <version.javax.ws.rs-api>2.1</version.javax.ws.rs-api>
     </properties>
 
     <dependencyManagement>
@@ -103,14 +107,16 @@
                 <artifactId>unirest-java</artifactId>
                 <version>${version.unirest}</version>
             </dependency>
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${version.javax.ws.rs-api}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.wildfly.swarm</groupId>
-            <artifactId>jaxrs</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-core</artifactId>
@@ -157,38 +163,103 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.swarm</groupId>
-                <artifactId>wildfly-swarm-plugin</artifactId>
-                <version>${version.wildfly.swarm}</version>
-                <configuration>
-                    <properties>
-                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                        <swarm.http.port>${name.port}</swarm.http.port>
-                    </properties>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
+        <profile>
+            <id>wildfly</id>
+            <!-- Wildfly JAX-RS -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.swarm</groupId>
+                    <artifactId>jaxrs</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.swarm</groupId>
+                        <artifactId>wildfly-swarm-plugin</artifactId>
+                        <version>${version.wildfly.swarm}</version>
+                        <configuration>
+                            <properties>
+                                <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                                <swarm.http.port>${name.port}</swarm.http.port>
+                            </properties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>openliberty</id>
+            <!-- JavaEE JAX-RS -->
+            <dependencies>
+                <dependency>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <version>${version.liberty-maven-plugin}</version>
+                        <configuration>
+                            <!-- Open Liberty runtime -->
+                            <assemblyArtifact>
+                                <groupId>io.openliberty</groupId>
+                                <artifactId>openliberty-runtime</artifactId>
+                                <version>${version.openliberty-runtime}</version>
+                                <type>zip</type>
+                            </assemblyArtifact>
+                            <configFile>src/main/openliberty/config/server.xml</configFile>
+                            <include>usr</include>
+                            <bootstrapProperties>
+                                <default.http.port>${name.port}</default.http.port>
+                            </bootstrapProperties>
+                        </configuration>
+                        <executions>
+                            <!-- Create the defaultServer -->
+                            <execution>
+                                <id>create-default-server</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>create-server</goal>
+                                </goals>
+                            </execution>
+                            <!-- Install the service war into the defaultServer apps/ directory-->
+                            <execution>
+                                <id>install-app</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>install-apps</goal>
+                                </goals>
+                                <configuration>
+                                    <appsDirectory>apps</appsDirectory>
+                                    <stripVersion>true</stripVersion>
+                                    <installAppPackages>project</installAppPackages>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>docker</id>
             <build>
@@ -207,6 +278,67 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>fabric8-maven-plugin</artifactId>
                         <version>${version.fabric8.maven.plugin}</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker-openliberty</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.7.0</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*Handler.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${version.fabric8.maven.plugin}</version>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>arungupta/${project.artifactId}:openliberty</name>
+                                    <build>
+                                        <from>open-liberty:microProfile1-java8-ibm</from>
+                                        <assembly>
+                                            <mode>dir</mode>
+                                            <targetDir>/opt/ol/wlp/usr/servers/defaultServer</targetDir>
+                                            <inline>
+                                                <files>
+                                                    <file>
+                                                        <source>./target/${project.artifactId}.war</source>
+                                                        <outputDirectory>./apps</outputDirectory>
+                                                    </file>
+                                                    <file>
+                                                        <source>./src/main/openliberty/config/server.xml</source>
+                                                        <outputDirectory>.</outputDirectory>
+                                                    </file>
+                                                    <file>
+                                                        <source>./src/main/openliberty/config/bootstrap.properties</source>
+                                                        <outputDirectory>.</outputDirectory>
+                                                    </file>
+                                                </files>
+                                            </inline>
+                                        </assembly>
+                                        <ports>${name.port}</ports>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
                         <executions>
                             <execution>
                                 <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,38 @@
         </dependency>
     </dependencies>
 
+<!--     <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly.swarm}</version>
+                <configuration>
+                    <properties>
+                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                        <swarm.http.port>${name.port}</swarm.http.port>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build> -->
+
     <profiles>
         <profile>
             <id>wildfly</id>

--- a/src/main/java/org/aws/samples/compute/name/MyApplication.java
+++ b/src/main/java/org/aws/samples/compute/name/MyApplication.java
@@ -19,6 +19,7 @@ public class MyApplication extends Application {
     public Set<Class<?>> getClasses() {
         Set<Class<?>> classes = new java.util.HashSet<>();
         classes.add(NameEndpoint.class);
+        classes.add(NameMessageBodyWriter.class);
         return classes;
     }
 

--- a/src/main/openliberty/config/bootstrap.properties
+++ b/src/main/openliberty/config/bootstrap.properties
@@ -1,0 +1,1 @@
+default.http.port=8082

--- a/src/main/openliberty/config/server.xml
+++ b/src/main/openliberty/config/server.xml
@@ -1,0 +1,12 @@
+<server description="The name service">
+
+  <featureManager>
+    <feature>jaxrs-2.0</feature>
+    <feature>cdi-1.2</feature>
+  </featureManager>
+
+  <httpEndpoint httpPort="${default.http.port}" id="defaultHttpEndpoint" host="*" />
+
+  <webApplication location="name.war" contextRoot="/" />
+
+</server>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,7 @@
     </filter>
     <filter-mapping>
         <filter-name>XRayServletFilter</filter-name>
-        <url-pattern>*</url-pattern>
+        <url-pattern>/*</url-pattern>
     </filter-mapping>
 
 </web-app>


### PR DESCRIPTION
@arun-gupta From the old PR:

Added three new profiles: `wildfly` for starting the service in Wildfly, `openliberty` for starting the service in Open Liberty, `docker-openliberty` for building a Docker image for Open Liberty.

To start the service in Wildfly as before, run:

```
mvn wildfly-swarm:run -P wildfly
```

To start the service in Open Liberty, run:

```
mvn install liberty:start-server -P openliberty
```

Just in case, run the `clean` goal when switching between runtimes.

**New files:**

The `src/main/openliberty/config` directory contains two files:

- `server.xml` contains the server configuration. This is where you can enable various features in the server.
- `bootstrap.properties` contains the runtime variables.

**Justification for code changes:**

- Added a slash to the url pattern in the `web.xml` file as outlined in the servlet spec.

- Open Liberty also requires the JavaEE JAX-RS, so hence the reason for adding `javax.ws.rs-api` dependency and separating the two JAX-RS versions into the two profiles.

- Added the `NameMessageBodyWriter` class to `getClasses()` method in `MyApplication.java` so that its visible.